### PR TITLE
Update 123_WPO_dual_class.tpa

### DIFF
--- a/scales_of_balance/components/123_WPO_dual_class.tpa
+++ b/scales_of_balance/components/123_WPO_dual_class.tpa
@@ -435,7 +435,7 @@ ACTION_IF FILE_EXISTS_IN_GAME ~CLABMA01.2da~ THEN BEGIN
 		APPEND_FILE ~scales_of_balance/profs/dualfm.txt~
 		BUT_ONLY
 END
-ACTION_IF NOT FILE_EXISTS_IN_GAME ~CLABMA01.2da~ THEN BEGIN
+ELSE THEN BEGIN
 	COPY ~scales_of_balance/profs/clabmaxx.2da~ ~override/clabma01.2da~
 		LPM remove_blank_lines
 		APPEND_FILE ~scales_of_balance/profs/dualfm.txt~


### PR DESCRIPTION
Otherwise It won't copy properly 'clabma01.2da' to override and the component [SBO - Stat-based Bonus Spells] will get the error: 
"ERROR locating resource for 'APPEND'
Resource [CLABMA02.2DA] not found in KEY file:
	[./chitin.key]
Stopping installation because of error.
ERROR: [kitlist.2da] -> [override/kitlist.2da] Patching Failed (COPY) (Failure("resource [CLABMA02.2DA] not found for 'APPEND'"))
Stopping installation because of error.
Stopping installation because of error.
"

Changing "ACTION_IF NOT FILE_EXISTS_IN_GAME ~CLABMA01.2da~" -> "ELSE" at the line 438 Solves the problem during the installation.